### PR TITLE
fix: return FieldProxy from metaclass instead of OOFieldInfo

### DIFF
--- a/src/oold/model/__init__.py
+++ b/src/oold/model/__init__.py
@@ -18,7 +18,7 @@ import pydantic
 import pydantic.fields
 from pydantic import BaseModel, GetCoreSchemaHandler
 from pydantic.fields import FieldInfo
-from pydantic_core import core_schema
+from pydantic_core import PydanticUndefined, core_schema
 from typing_extensions import Self, get_args
 
 from oold.backend import interface
@@ -77,6 +77,55 @@ class OOFieldInfo(FieldInfo):
 
 
 pydantic.fields.FieldInfo = OOFieldInfo
+
+
+class FieldProxy:
+    """Returned by metaclass __getattribute__ for class-level field access.
+    Supports comparison operators for query syntax (Entity.name == "test")
+    and forwards attribute access / truthiness to the field's default value."""
+
+    __slots__ = ("_default", "name", "parent")
+
+    def __init__(self, default, name, parent):
+        object.__setattr__(self, "_default", default)
+        object.__setattr__(self, "name", name)
+        object.__setattr__(self, "parent", parent)
+
+    def __eq__(self, other):
+        return Condition(field=self.name, operator="eq", value=other)
+
+    def __ne__(self, other):
+        return Condition(field=self.name, operator="ne", value=other)
+
+    def __lt__(self, other):
+        return Condition(field=self.name, operator="lt", value=other)
+
+    def __le__(self, other):
+        return Condition(field=self.name, operator="le", value=other)
+
+    def __gt__(self, other):
+        return Condition(field=self.name, operator="gt", value=other)
+
+    def __ge__(self, other):
+        return Condition(field=self.name, operator="ge", value=other)
+
+    def __hash__(self):
+        return id(self)
+
+    def __bool__(self):
+        d = object.__getattribute__(self, "_default")
+        if d is None or d is PydanticUndefined:
+            return False
+        return bool(d)
+
+    def __getattr__(self, name):
+        d = object.__getattribute__(self, "_default")
+        if d is not None and d is not PydanticUndefined:
+            return getattr(d, name)
+        raise AttributeError(
+            f"'{type(self).__name__}' object has no attribute '{name}'"
+        )
+
 
 # pydantic v2
 _types: Dict[str, pydantic.main._model_construction.ModelMetaclass] = {}
@@ -139,9 +188,7 @@ class LinkedBaseModelMetaClass(pydantic.main._model_construction.ModelMetaclass)
                     # ToDo: lookup the fields property if available
                     # return Condition(field=name)
                     field_info = self.model_fields[name]
-                    field_info.name = name
-                    field_info.parent = self
-                    return field_info
+                    return FieldProxy(field_info.default, name, self)
                     # f = super().__getattribute__(name)
                     # return f
                 else:

--- a/src/oold/model/v1/__init__.py
+++ b/src/oold/model/v1/__init__.py
@@ -81,6 +81,54 @@ class OOFieldInfo(FieldInfo):
 pydantic.v1.fields.FieldInfo = OOFieldInfo
 
 
+class FieldProxy:
+    """Returned by metaclass __getattribute__ for class-level field access.
+    Supports comparison operators for query syntax (Entity.name == "test")
+    and forwards attribute access / truthiness to the field's default value."""
+
+    __slots__ = ("_default", "name", "parent")
+
+    def __init__(self, default, name, parent):
+        object.__setattr__(self, "_default", default)
+        object.__setattr__(self, "name", name)
+        object.__setattr__(self, "parent", parent)
+
+    def __eq__(self, other):
+        return Condition(field=self.name, operator="eq", value=other)
+
+    def __ne__(self, other):
+        return Condition(field=self.name, operator="ne", value=other)
+
+    def __lt__(self, other):
+        return Condition(field=self.name, operator="lt", value=other)
+
+    def __le__(self, other):
+        return Condition(field=self.name, operator="le", value=other)
+
+    def __gt__(self, other):
+        return Condition(field=self.name, operator="gt", value=other)
+
+    def __ge__(self, other):
+        return Condition(field=self.name, operator="ge", value=other)
+
+    def __hash__(self):
+        return id(self)
+
+    def __bool__(self):
+        d = object.__getattribute__(self, "_default")
+        if d is None or d is ...:
+            return False
+        return bool(d)
+
+    def __getattr__(self, name):
+        d = object.__getattribute__(self, "_default")
+        if d is not None and d is not ...:
+            return getattr(d, name)
+        raise AttributeError(
+            f"'{type(self).__name__}' object has no attribute '{name}'"
+        )
+
+
 # pydantic v1
 _types: Dict[str, pydantic.v1.main.ModelMetaclass] = {}
 
@@ -127,10 +175,8 @@ class LinkedBaseModelMetaClass(pydantic.v1.main.ModelMetaclass):
                     and hasattr(self, "__fields__")
                     and name in self.__fields__
                 ):
-                    field_info = self.__fields__[name].field_info
-                    field_info.name = name
-                    field_info.parent = self
-                    return field_info
+                    field = self.__fields__[name]
+                    return FieldProxy(field.default, name, self)
                 else:
                     return super().__getattribute__(name)
             return super().__getattribute__(name)


### PR DESCRIPTION
The metaclass __getattribute__ previously returned OOFieldInfo for class-level field access (e.g. Entity.meta). This broke downstream code that accessed default values via class attributes, since OOFieldInfo lacks the default value's attributes.

Introduce FieldProxy, a lightweight wrapper returned by the metaclass that supports both query operators (Entity.name == "test") and transparent forwarding of attribute access / truthiness to the field's default value. OOFieldInfo stays clean for pydantic's internal use.