### PR TITLE
refactor auth: add credential types, IRI matching, YAML persistence, …

### DIFF
--- a/src/oold/backend/auth.py
+++ b/src/oold/backend/auth.py
@@ -1,94 +1,439 @@
+import contextvars
 import getpass
+import logging
 from enum import Enum
-from typing import List, Optional, Union
+from pathlib import Path
+from typing import ClassVar, Dict, List, Optional, Union
 
 from pydantic import BaseModel, SecretStr
 
-global _credentials
-_credentials = {}
+_logger = logging.getLogger(__name__)
+
+
+# Credential types
 
 
 class BaseCredential(BaseModel):
-    """Abstract base class for credentials"""
+    """Abstract base class for credentials."""
 
-    iri: Union[str, List[str]]
-    """the IRI(s) the credential is valid for"""
+    iri: str
+    """The IRI this credential is valid for."""
 
 
 class UserPwdCredential(BaseCredential):
-    """a username - password credential"""
+    """Username and password authentication."""
 
     username: str
-    """the user identifier"""
     password: SecretStr
-    """the users password"""
 
 
-class CredentialFallback(str, Enum):
-    """Modes of handling missing credentials
+class TokenCredential(BaseCredential):
+    """Bearer token authentication (API keys, JWTs, etc.)."""
 
-    Attributes
-    ----------
-    none:
-        throw error
-    ask:
-        use getpass to ask for credentials
+    token: SecretStr
+
+
+class OAuth1Credential(BaseCredential):
+    """OAuth1 credentials.
+
+    See https://requests-oauthlib.readthedocs.io/en/latest/oauth1_workflow.html
     """
 
-    ask = "ask"  # use getpass to ask for credentials
-    none = "none"  # throw error
+    consumer_token: str
+    consumer_secret: SecretStr
+    access_token: str
+    access_secret: SecretStr
 
 
-class GetCredentialParam(BaseModel):
-    """Reads credentials from a yaml file"""
+class OAuth2Credential(BaseCredential):
+    """OAuth2 credentials with access and optional refresh token."""
 
-    iri: str
-    """internationalized resource identifier / address of the service, may contain
-    protocol, domain, port and path matches by "contains" returning the shortest
-    match"""
-    fallback: Optional[CredentialFallback] = CredentialFallback.none
-    """The fallback strategy if no credential was found for the given origin"""
+    access_token: SecretStr
+    refresh_token: Optional[SecretStr] = None
+    token_type: str = "Bearer"
 
 
-class SetCredentialParam(BaseModel):
-    credential: BaseCredential
+class CertificateCredential(BaseCredential):
+    """TLS client certificate authentication."""
+
+    cert_path: str
+    key_path: Optional[str] = None
+    ca_path: Optional[str] = None
 
 
-def set_credential(param: SetCredentialParam) -> None:
-    global _credentials
-    iris = (
-        param.credential.iri
-        if isinstance(param.credential.iri, list)
-        else [param.credential.iri]
-    )
-    for iri in iris:
-        _credentials[iri] = param.credential
+# Registry for credential type inference from YAML fields
+
+# Ordered most-specific-first so the first full match wins
+_CREDENTIAL_TYPES: List[type] = [
+    OAuth1Credential,
+    OAuth2Credential,
+    CertificateCredential,
+    UserPwdCredential,
+    TokenCredential,
+]
+
+_BASE_FIELDS = {"iri"}
 
 
-def get_credential(param: GetCredentialParam) -> BaseCredential:
-    match_iri = ""
-    cred = None
-    iris = _credentials.keys()
-    for iri in iris:
-        if iri in param.iri:
-            if match_iri == "" or len(match_iri) > len(
-                iri
-            ):  # use the less specific match
-                match_iri = iri
+def _infer_credential_type(data: dict) -> type:
+    """Infer the most specific credential class from a dict of fields."""
+    for cls in _CREDENTIAL_TYPES:
+        required = {
+            name
+            for name, field in cls.model_fields.items()
+            if field.is_required() and name not in _BASE_FIELDS
+        }
+        if required <= data.keys():
+            return cls
+    return BaseCredential
 
-    if match_iri != "":
-        cred = _credentials.get(match_iri, None)
 
+# Context-var credential store
+
+_credentials: contextvars.ContextVar[
+    Dict[str, BaseCredential]
+] = contextvars.ContextVar("oold_credentials", default={})
+
+
+def set_credential(credential: BaseCredential):
+    """Store a credential. The credential's ``iri`` field is used as the key."""
+    creds = _credentials.get().copy()
+    creds[credential.iri] = credential
+    _credentials.set(creds)
+
+
+def get_credential(iri: str, exact: bool = False) -> BaseCredential:
+    """Retrieve the credential for the given IRI from the global store.
+
+    Parameters
+    ----------
+    iri
+        The IRI to look up.
+    exact
+        If True, only exact key matches are returned.
+    """
+    creds = _credentials.get()
+    cred = find_credential(iri, creds, exact=exact)
     if cred is None:
-        if param.fallback is CredentialFallback.ask:
-            print(
-                f"No credentials for {param.iri} found. "
-                f"Please use the prompt to login"
-            )
+        raise ValueError(f"No credentials found for {iri}")
+    return cred
+
+
+# IRI matching
+
+
+def find_credential(
+    iri: str,
+    credentials: Dict[str, BaseCredential],
+    exact: bool = False,
+) -> Optional[BaseCredential]:
+    """Find the best matching credential for the given IRI.
+
+    Matching strategy (when ``exact=False``):
+
+    1. **Exact match** - IRI equals a stored key.
+
+    2. **Stored-in-search** (most specific wins) - a stored IRI is a
+       substring of the search IRI. The longest stored IRI wins.
+       Use case: controller has a full URL, finds the best credential.
+       Example: search ``"https://wiki.example.com:443/api"`` matches
+       stored ``"wiki.example.com:443/api"`` over ``"wiki.example.com"``.
+
+    3. **Search-in-stored** (broadest wins) - the search IRI is a
+       substring of a stored IRI. The shortest stored IRI wins.
+       Use case: user remembers a domain fragment, finds the credential.
+       Example: search ``"domain.com"`` matches stored ``"test.domain.com"``.
+
+    Step 2 is tried before step 3 because a specific credential that
+    covers the full URL is a stronger match than a broad key that
+    happens to contain the search term.
+
+    Parameters
+    ----------
+    iri
+        The IRI to search for.
+    credentials
+        Dict of stored IRI to BaseCredential.
+    exact
+        If True, only exact key matches are returned.
+    """
+    # 1. Exact match
+    if iri in credentials:
+        return credentials[iri]
+
+    if exact:
+        return None
+
+    # 2. Stored IRI is substring of search IRI (longest/most-specific wins)
+    best_len = 0
+    best_cred = None
+    for stored_iri, cred in credentials.items():
+        if stored_iri in iri and len(stored_iri) > best_len:
+            best_len = len(stored_iri)
+            best_cred = cred
+    if best_cred is not None:
+        return best_cred
+
+    # 3. Search IRI is substring of stored IRI (shortest/broadest wins)
+    best_len = 0
+    best_cred = None
+    for stored_iri, cred in credentials.items():
+        if iri in stored_iri:
+            if best_len == 0 or len(stored_iri) < best_len:
+                best_len = len(stored_iri)
+                best_cred = cred
+    return best_cred
+
+
+# YAML persistence
+
+
+def _secret_value(v) -> str:
+    """Extract plain string from a SecretStr or pass through."""
+    if isinstance(v, SecretStr):
+        return v.get_secret_value()
+    return v
+
+
+def dump_credentials(
+    filepath: Union[str, Path],
+    credentials: Optional[Dict[str, BaseCredential]] = None,
+):
+    """Save credentials to a YAML file.
+
+    Format::
+
+        wiki.example.com:
+          username: admin
+          password: secret
+        api.example.com:
+          token: jwt_xyz
+
+    The ``iri`` field is used as the YAML key and excluded from the value dict.
+
+    Parameters
+    ----------
+    filepath
+        Path to write the YAML file.
+    credentials
+        Dict of IRI to BaseCredential. If None, dumps the current context-var store.
+    """
+    import yaml
+
+    if credentials is None:
+        credentials = _credentials.get()
+
+    data = {}
+    for iri, cred in credentials.items():
+        entry = {}
+        for name, value in cred.model_dump().items():
+            if name == "iri" or value is None:
+                continue
+            entry[name] = _secret_value(value)
+        data[iri] = entry
+
+    filepath = Path(filepath)
+    filepath.parent.mkdir(parents=True, exist_ok=True)
+    with open(filepath, "w", encoding="utf-8") as f:
+        yaml.dump(data, f, default_flow_style=False, allow_unicode=True)
+
+
+def load_credentials(
+    filepath: Union[str, Path],
+    into_store: bool = True,
+) -> Dict[str, BaseCredential]:
+    """Load credentials from a YAML file.
+
+    The credential type is inferred from the fields present in each entry
+    (e.g. ``username`` + ``password`` produces a ``UserPwdCredential``).
+    The YAML key becomes the ``iri`` field.
+
+    Parameters
+    ----------
+    filepath
+        Path to the YAML file.
+    into_store
+        If True, loaded credentials are also stored into the context-var store.
+
+    Returns
+    -------
+    dict
+        IRI to BaseCredential mapping.
+    """
+    import yaml
+
+    filepath = Path(filepath)
+    if not filepath.exists():
+        raise FileNotFoundError(f"Credentials file not found: {filepath}")
+
+    with open(filepath, "r", encoding="utf-8") as f:
+        raw = yaml.safe_load(f)
+
+    if raw is None:
+        return {}
+
+    result: Dict[str, BaseCredential] = {}
+    for iri, fields in raw.items():
+        if not isinstance(fields, dict):
+            continue
+        cls = _infer_credential_type(fields)
+        coerced = {"iri": iri}
+        for key, value in fields.items():
+            field_info = cls.model_fields.get(key)
+            if field_info and field_info.annotation in (
+                SecretStr,
+                Optional[SecretStr],
+            ):
+                coerced[key] = (
+                    SecretStr(value) if not isinstance(value, SecretStr) else value
+                )
+            else:
+                coerced[key] = value
+        result[iri] = cls(**coerced)
+
+    if into_store:
+        creds = _credentials.get().copy()
+        creds.update(result)
+        _credentials.set(creds)
+
+    return result
+
+
+# CredentialManager
+
+
+class CredentialManager(BaseModel):
+    """Manages credentials from YAML files and the global in-memory store.
+
+    Compatible with osw.auth.CredentialManager API.
+    """
+
+    cred_filepath: Optional[Union[Union[str, Path], List[Union[str, Path]]]] = None
+    """Filepath(s) to YAML file(s) with credentials."""
+
+    class CredentialFallback(str, Enum):
+        ask = "ask"
+        none = "none"
+
+    class CredentialConfig(BaseModel):
+        iri: str
+        """IRI to look up."""
+        fallback: Optional[str] = "none"
+        """Fallback strategy if no credential found: 'ask' or 'none'."""
+
+    # Re-export credential types as nested classes for osw compatibility
+    BaseCredential: ClassVar[type] = BaseCredential
+    UserPwdCredential: ClassVar[type] = UserPwdCredential
+    TokenCredential: ClassVar[type] = TokenCredential
+    OAuth1Credential: ClassVar[type] = OAuth1Credential
+    OAuth2Credential: ClassVar[type] = OAuth2Credential
+    CertificateCredential: ClassVar[type] = CertificateCredential
+
+    def model_post_init(self, __context):
+        if self.cred_filepath is not None:
+            if not isinstance(self.cred_filepath, list):
+                self.cred_filepath = [self.cred_filepath]
+            self.cred_filepath = [Path(fp) for fp in self.cred_filepath if fp != ""]
+
+    def _load_file_credentials(self) -> Dict[str, BaseCredential]:
+        """Load credentials from all configured YAML files."""
+        result: Dict[str, BaseCredential] = {}
+        if not self.cred_filepath:
+            return result
+        for fp in self.cred_filepath:
+            fp = Path(fp)
+            if not fp.exists():
+                continue
+            try:
+                loaded = load_credentials(fp, into_store=False)
+                result.update(loaded)
+            except Exception as e:
+                _logger.error("Error loading credentials from %s: %s", fp, e)
+        return result
+
+    def get_credential(
+        self, config: "CredentialManager.CredentialConfig"
+    ) -> Optional[BaseCredential]:
+        """Look up a credential by IRI.
+
+        Uses combined matching: exact, then stored-in-search (most specific),
+        then search-in-stored (broadest). Falls back to getpass if fallback='ask'.
+
+        Parameters
+        ----------
+        config
+            Lookup configuration with IRI and fallback strategy.
+        """
+        file_creds = self._load_file_credentials()
+        store_creds = _credentials.get()
+        all_creds = {**file_creds, **store_creds}
+
+        cred = find_credential(config.iri, all_creds)
+        if cred is not None:
+            return cred
+
+        # Fallback
+        fallback = config.fallback
+        if isinstance(fallback, str):
+            fallback = self.CredentialFallback(fallback)
+
+        if fallback == self.CredentialFallback.ask:
+            if self.cred_filepath:
+                paths = ", ".join(str(fp) for fp in self.cred_filepath)
+                print(
+                    f"No credentials for {config.iri} found in '{paths}'. "
+                    f"Please use the prompt to login"
+                )
             username = input("Enter username: ")
             password = getpass.getpass("Enter password: ")
             cred = UserPwdCredential(
-                username=username, password=password, iri=param.iri
+                iri=config.iri,
+                username=username,
+                password=SecretStr(password),
             )
-            set_credential(SetCredentialParam(credential=cred))
-    return cred
+            self.add_credential(cred)
+            if self.cred_filepath:
+                self.save_credentials_to_file()
+            return cred
+
+        return None
+
+    def add_credential(self, cred: BaseCredential):
+        """Add a credential to the global store."""
+        set_credential(cred)
+
+    def iri_in_credentials(self, iri: str) -> bool:
+        """Check if a credential for the given IRI exists in the store."""
+        creds = _credentials.get()
+        return iri in creds
+
+    def iri_in_file(self, iri: str) -> bool:
+        """Check if a credential for the given IRI exists in any YAML file."""
+        file_creds = self._load_file_credentials()
+        return iri in file_creds
+
+    def save_credentials_to_file(
+        self,
+        filepath: Optional[Union[str, Path]] = None,
+    ):
+        """Save in-memory credentials to YAML file(s).
+
+        Parameters
+        ----------
+        filepath
+            Target file. If None, uses the configured cred_filepath(s).
+        """
+        targets = [Path(filepath)] if filepath else (self.cred_filepath or [])
+        creds = _credentials.get()
+        for fp in targets:
+            fp = Path(fp)
+            existing = {}
+            if fp.exists():
+                try:
+                    existing = load_credentials(fp, into_store=False)
+                except Exception:
+                    pass
+            merged = {**existing}
+            merged.update(creds)
+            dump_credentials(fp, credentials=merged)
+            _logger.info("Credentials saved to '%s'.", fp.resolve())

--- a/src/oold/backend/sparql.py
+++ b/src/oold/backend/sparql.py
@@ -5,7 +5,7 @@ from pydantic import ConfigDict
 from rdflib import Graph
 from SPARQLWrapper import JSONLD, SPARQLWrapper
 
-from oold.backend.auth import GetCredentialParam, UserPwdCredential, get_credential
+from oold.backend.auth import UserPwdCredential, get_credential
 from oold.backend.interface import Backend, Resolver, StoreResult
 
 
@@ -29,6 +29,7 @@ class LocalSparqlResolver(Resolver):
             # check if the iri is a full IRI or a prefix
             if iri.startswith("http"):
                 iri_filter = f"FILTER (?s = <{iri}>)"
+            # todo: build full iri / prefix mapping from model context
             qres = self.graph.query(
                 """
                 PREFIX ex: <https://example.com/>
@@ -92,7 +93,10 @@ class SparqlResolver(Resolver):
         jsonld_dicts = {}
 
         # lookup  credential for the endpoint
-        cred = get_credential(GetCredentialParam(iri=self.endpoint))
+        try:
+            cred = get_credential(self.endpoint)
+        except ValueError:
+            cred = None
         if cred is not None:
             if isinstance(cred, UserPwdCredential):
                 self._sparql.setCredentials(

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,503 @@
+import contextvars
+import os
+import tempfile
+
+import pytest
+from pydantic import SecretStr
+
+from oold.backend.auth import (
+    BaseCredential,
+    CertificateCredential,
+    CredentialManager,
+    OAuth1Credential,
+    OAuth2Credential,
+    TokenCredential,
+    UserPwdCredential,
+    dump_credentials,
+    get_credential,
+    load_credentials,
+    set_credential,
+)
+
+# -- Basic set/get --
+
+
+def test_set_and_get_credential():
+    set_credential(
+        UserPwdCredential(
+            iri="localhost:8080", username="admin", password=SecretStr("pass123")
+        )
+    )
+    cred = get_credential("localhost:8080")
+    assert isinstance(cred, UserPwdCredential)
+    assert cred.iri == "localhost:8080"
+    assert cred.username == "admin"
+    assert cred.password.get_secret_value() == "pass123"
+
+
+def test_set_credential_with_token():
+    set_credential(TokenCredential(iri="api.example.com", token=SecretStr("tok_abc")))
+    cred = get_credential("api.example.com")
+    assert isinstance(cred, TokenCredential)
+    assert cred.token.get_secret_value() == "tok_abc"
+
+
+def test_get_credential_missing_raises():
+    with pytest.raises(ValueError, match="No credentials found"):
+        get_credential("nonexistent.host:9999")
+
+
+def test_overwrite_credential():
+    set_credential(
+        UserPwdCredential(
+            iri="overwrite.test", username="user1", password=SecretStr("pass1")
+        )
+    )
+    set_credential(
+        UserPwdCredential(
+            iri="overwrite.test", username="user2", password=SecretStr("pass2")
+        )
+    )
+    cred = get_credential("overwrite.test")
+    assert cred.username == "user2"
+
+
+def test_contextvars_isolation():
+    """Credentials set in a child context should not affect the parent."""
+    set_credential(
+        UserPwdCredential(
+            iri="parent.test", username="parent_user", password=SecretStr("parent_pass")
+        )
+    )
+
+    ctx = contextvars.copy_context()
+
+    def child():
+        set_credential(
+            UserPwdCredential(
+                iri="child.test",
+                username="child_user",
+                password=SecretStr("child_pass"),
+            )
+        )
+        assert get_credential("child.test").username == "child_user"
+        assert get_credential("parent.test").username == "parent_user"
+
+    ctx.run(child)
+
+    with pytest.raises(ValueError):
+        get_credential("child.test")
+    assert get_credential("parent.test").username == "parent_user"
+
+
+# -- IRI matching --
+
+
+def test_get_credential_exact_match():
+    set_credential(
+        UserPwdCredential(
+            iri="match.exact.test", username="exact_user", password=SecretStr("p")
+        )
+    )
+    cred = get_credential("match.exact.test", exact=True)
+    assert cred.username == "exact_user"
+
+
+def test_get_credential_exact_match_missing_raises():
+    set_credential(
+        UserPwdCredential(iri="match.exact.base", username="u", password=SecretStr("p"))
+    )
+    with pytest.raises(ValueError):
+        get_credential("match.exact.base/subpath", exact=True)
+
+
+def test_get_credential_substring_match():
+    """Stored IRI is a substring of the search IRI."""
+    set_credential(
+        UserPwdCredential(
+            iri="match.sub.host", username="sub_user", password=SecretStr("p")
+        )
+    )
+    cred = get_credential("https://match.sub.host:443/api")
+    assert cred.username == "sub_user"
+
+
+def test_get_credential_most_specific_match():
+    """Longest stored IRI that is a substring of the search wins."""
+    set_credential(
+        UserPwdCredential(
+            iri="specificity.host", username="general", password=SecretStr("p")
+        )
+    )
+    set_credential(
+        UserPwdCredential(
+            iri="specificity.host:443",
+            username="port_specific",
+            password=SecretStr("p"),
+        )
+    )
+    set_credential(
+        UserPwdCredential(
+            iri="specificity.host:443/api",
+            username="path_specific",
+            password=SecretStr("p"),
+        )
+    )
+
+    cred = get_credential("https://specificity.host:443/api/v2")
+    assert cred.username == "path_specific"
+
+    cred = get_credential("https://specificity.host:443/other")
+    assert cred.username == "port_specific"
+
+    cred = get_credential("https://specificity.host:8080/other")
+    assert cred.username == "general"
+
+
+def test_get_credential_no_substring_match_raises():
+    set_credential(
+        UserPwdCredential(iri="nomatch.host", username="u", password=SecretStr("p"))
+    )
+    with pytest.raises(ValueError):
+        get_credential("completely.different.host")
+
+
+# -- Credential class hierarchy --
+
+
+def test_base_credential():
+    cred = BaseCredential(iri="base.test")
+    assert cred.iri == "base.test"
+
+
+def test_user_pwd_credential():
+    cred = UserPwdCredential(
+        iri="u.test", username="admin", password=SecretStr("s3cret")
+    )
+    assert isinstance(cred, BaseCredential)
+    assert cred.username == "admin"
+    assert cred.password.get_secret_value() == "s3cret"
+
+
+def test_user_pwd_credential_requires_fields():
+    with pytest.raises(Exception):
+        UserPwdCredential(iri="u.test")
+
+
+def test_token_credential():
+    cred = TokenCredential(iri="t.test", token=SecretStr("jwt_xyz"))
+    assert isinstance(cred, BaseCredential)
+    assert cred.token.get_secret_value() == "jwt_xyz"
+
+
+def test_token_credential_requires_token():
+    with pytest.raises(Exception):
+        TokenCredential(iri="t.test")
+
+
+def test_oauth1_credential():
+    cred = OAuth1Credential(
+        iri="o1.test",
+        consumer_token="ct",
+        consumer_secret=SecretStr("cs"),
+        access_token="at",
+        access_secret=SecretStr("as"),
+    )
+    assert isinstance(cred, BaseCredential)
+    assert cred.consumer_token == "ct"
+    assert cred.consumer_secret.get_secret_value() == "cs"
+
+
+def test_oauth2_credential():
+    cred = OAuth2Credential(
+        iri="o2.test",
+        access_token=SecretStr("access_tok"),
+        refresh_token=SecretStr("refresh_tok"),
+    )
+    assert isinstance(cred, BaseCredential)
+    assert cred.access_token.get_secret_value() == "access_tok"
+    assert cred.token_type == "Bearer"
+
+
+def test_oauth2_credential_minimal():
+    cred = OAuth2Credential(iri="o2m.test", access_token=SecretStr("tok"))
+    assert cred.refresh_token is None
+
+
+def test_certificate_credential():
+    cred = CertificateCredential(
+        iri="cert.test",
+        cert_path="/path/to/cert.pem",
+        key_path="/path/to/key.pem",
+        ca_path="/path/to/ca.pem",
+    )
+    assert isinstance(cred, BaseCredential)
+    assert cred.cert_path == "/path/to/cert.pem"
+
+
+def test_certificate_credential_minimal():
+    cred = CertificateCredential(iri="certm.test", cert_path="/cert.pem")
+    assert cred.key_path is None
+    assert cred.ca_path is None
+
+
+# -- set_credential preserves type --
+
+
+def test_set_get_preserves_user_pwd_type():
+    set_credential(
+        UserPwdCredential(
+            iri="db.example.com:5432", username="db_user", password=SecretStr("db_pass")
+        )
+    )
+    retrieved = get_credential("db.example.com:5432")
+    assert isinstance(retrieved, UserPwdCredential)
+
+
+def test_set_get_preserves_oauth1_type():
+    set_credential(
+        OAuth1Credential(
+            iri="wiki.typed.com",
+            consumer_token="ct",
+            consumer_secret=SecretStr("cs"),
+            access_token="at",
+            access_secret=SecretStr("as"),
+        )
+    )
+    retrieved = get_credential("wiki.typed.com")
+    assert isinstance(retrieved, OAuth1Credential)
+
+
+def test_set_get_preserves_token_type():
+    set_credential(
+        TokenCredential(iri="postgrest.local:3000", token=SecretStr("pgrst_jwt"))
+    )
+    retrieved = get_credential("postgrest.local:3000")
+    assert isinstance(retrieved, TokenCredential)
+
+
+# -- IRI is part of credential --
+
+
+def test_credential_iri_accessible():
+    set_credential(
+        UserPwdCredential(iri="iri.access.test", username="u", password=SecretStr("p"))
+    )
+    cred = get_credential("iri.access.test")
+    assert cred.iri == "iri.access.test"
+
+
+# -- YAML dump and load --
+
+
+@pytest.fixture
+def yaml_path():
+    with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as f:
+        path = f.name
+    yield path
+    if os.path.exists(path):
+        os.unlink(path)
+
+
+def test_dump_and_load_user_pwd(yaml_path):
+    creds = {
+        "wiki.test.com": UserPwdCredential(
+            iri="wiki.test.com", username="admin", password=SecretStr("secret")
+        ),
+    }
+    dump_credentials(yaml_path, credentials=creds)
+
+    loaded = load_credentials(yaml_path, into_store=False)
+    assert "wiki.test.com" in loaded
+    assert isinstance(loaded["wiki.test.com"], UserPwdCredential)
+    assert loaded["wiki.test.com"].iri == "wiki.test.com"
+    assert loaded["wiki.test.com"].username == "admin"
+    assert loaded["wiki.test.com"].password.get_secret_value() == "secret"
+
+
+def test_dump_and_load_token(yaml_path):
+    creds = {
+        "api.test.com": TokenCredential(iri="api.test.com", token=SecretStr("my_jwt")),
+    }
+    dump_credentials(yaml_path, credentials=creds)
+
+    loaded = load_credentials(yaml_path, into_store=False)
+    assert isinstance(loaded["api.test.com"], TokenCredential)
+    assert loaded["api.test.com"].token.get_secret_value() == "my_jwt"
+
+
+def test_dump_and_load_oauth1(yaml_path):
+    creds = {
+        "oauth.test.com": OAuth1Credential(
+            iri="oauth.test.com",
+            consumer_token="ct",
+            consumer_secret=SecretStr("cs"),
+            access_token="at",
+            access_secret=SecretStr("as"),
+        ),
+    }
+    dump_credentials(yaml_path, credentials=creds)
+
+    loaded = load_credentials(yaml_path, into_store=False)
+    assert isinstance(loaded["oauth.test.com"], OAuth1Credential)
+    assert loaded["oauth.test.com"].consumer_token == "ct"
+
+
+def test_dump_and_load_mixed(yaml_path):
+    creds = {
+        "wiki.mixed.com": UserPwdCredential(
+            iri="wiki.mixed.com", username="u", password=SecretStr("p")
+        ),
+        "api.mixed.com": TokenCredential(iri="api.mixed.com", token=SecretStr("tok")),
+        "cert.mixed.com": CertificateCredential(
+            iri="cert.mixed.com", cert_path="/c.pem", key_path="/k.pem"
+        ),
+    }
+    dump_credentials(yaml_path, credentials=creds)
+
+    loaded = load_credentials(yaml_path, into_store=False)
+    assert len(loaded) == 3
+    assert isinstance(loaded["wiki.mixed.com"], UserPwdCredential)
+    assert isinstance(loaded["api.mixed.com"], TokenCredential)
+    assert isinstance(loaded["cert.mixed.com"], CertificateCredential)
+
+
+def test_dump_excludes_iri_from_yaml(yaml_path):
+    """IRI should be the YAML key, not repeated inside the value dict."""
+    import yaml
+
+    creds = {
+        "iri.key.test": UserPwdCredential(
+            iri="iri.key.test", username="u", password=SecretStr("p")
+        ),
+    }
+    dump_credentials(yaml_path, credentials=creds)
+
+    with open(yaml_path) as f:
+        raw = yaml.safe_load(f)
+    assert "iri" not in raw["iri.key.test"]
+    assert raw["iri.key.test"]["username"] == "u"
+
+
+def test_load_into_store(yaml_path):
+    creds = {
+        "store.load.test": UserPwdCredential(
+            iri="store.load.test", username="loaded", password=SecretStr("pw")
+        ),
+    }
+    dump_credentials(yaml_path, credentials=creds)
+
+    ctx = contextvars.copy_context()
+
+    def _check():
+        load_credentials(yaml_path, into_store=True)
+        cred = get_credential("store.load.test")
+        assert cred.username == "loaded"
+        assert cred.iri == "store.load.test"
+
+    ctx.run(_check)
+
+
+def test_dump_current_store(yaml_path):
+    ctx = contextvars.copy_context()
+
+    def _check():
+        set_credential(TokenCredential(iri="dump.store.test", token=SecretStr("t")))
+        dump_credentials(yaml_path)
+
+        loaded = load_credentials(yaml_path, into_store=False)
+        assert "dump.store.test" in loaded
+
+    ctx.run(_check)
+
+
+def test_load_osw_compatible_format(yaml_path):
+    """YAML in the format used by osw CredentialManager."""
+    import yaml
+
+    data = {
+        "wiki-dev.open-semantic-lab.org": {
+            "username": "Simon Stier",
+            "password": "stdPass@01",
+        },
+        "api.example.com": {
+            "consumer_token": "ct",
+            "consumer_secret": "cs",
+            "access_token": "at",
+            "access_secret": "as",
+        },
+    }
+    with open(yaml_path, "w") as f:
+        yaml.dump(data, f)
+
+    loaded = load_credentials(yaml_path, into_store=False)
+    wiki_cred = loaded["wiki-dev.open-semantic-lab.org"]
+    assert isinstance(wiki_cred, UserPwdCredential)
+    assert wiki_cred.iri == "wiki-dev.open-semantic-lab.org"
+    assert wiki_cred.username == "Simon Stier"
+
+    api_cred = loaded["api.example.com"]
+    assert isinstance(api_cred, OAuth1Credential)
+    assert api_cred.iri == "api.example.com"
+    assert api_cred.consumer_token == "ct"
+
+
+def test_load_missing_file_raises():
+    with pytest.raises(FileNotFoundError):
+        load_credentials("/nonexistent/path.yaml")
+
+
+# CredentialManager tests
+
+
+def test_credential_manager_single_file(yaml_path):
+    """osw-compatible: single file, substring match."""
+    import yaml
+
+    data = {"test.domain.com": {"username": "testuser", "password": "pass123"}}
+    with open(yaml_path, "w") as f:
+        yaml.dump(data, f)
+
+    cm = CredentialManager(cred_filepath=yaml_path)
+    cred = cm.get_credential(CredentialManager.CredentialConfig(iri="domain.com"))
+    assert cred is not None
+    assert cred.username == "testuser"
+    assert cred.password.get_secret_value() == "pass123"
+
+
+def test_credential_manager_multi_file(yaml_path):
+    import yaml
+
+    data1 = {"test.domain.com": {"username": "u1", "password": "p1"}}
+    data2 = {
+        "test.domain.com:80": {"username": "u2", "password": "p2"},
+        "domain.com:80": {"username": "u3", "password": "p3"},
+    }
+    path2 = yaml_path + ".2.yaml"
+    with open(yaml_path, "w") as f:
+        yaml.dump(data1, f)
+    with open(path2, "w") as f:
+        yaml.dump(data2, f)
+
+    cm = CredentialManager(cred_filepath=[yaml_path, path2])
+    cred = cm.get_credential(CredentialManager.CredentialConfig(iri="domain.com:80"))
+    assert cred.username == "u3"
+
+    os.unlink(path2)
+
+
+def test_credential_manager_add_credential():
+    cm = CredentialManager(cred_filepath=None)
+    cred = UserPwdCredential(
+        iri="added.test", username="added", password=SecretStr("pw")
+    )
+    cm.add_credential(cred)
+    result = cm.get_credential(CredentialManager.CredentialConfig(iri="added.test"))
+    assert result.username == "added"
+
+
+def test_credential_manager_nested_types():
+    """CredentialManager re-exports credential types as nested classes."""
+    assert CredentialManager.BaseCredential is BaseCredential
+    assert CredentialManager.UserPwdCredential is UserPwdCredential
+    assert CredentialManager.OAuth1Credential is OAuth1Credential


### PR DESCRIPTION
…and CredentialManager

- Add typed credential hierarchy: BaseCredential, UserPwdCredential, TokenCredential, OAuth1Credential, OAuth2Credential, CertificateCredential
- Add contextvars-based credential store (thread/async safe)
- Add combined IRI matching: exact, then stored-in-search (most specific), then search-in-stored (broadest)
- Add YAML dump/load with automatic credential type inference from fields
- Add CredentialManager class with multi-file support and getpass fallback
- Update sparql.py to use new get_credential(iri) API
- Add tests covering all credential types, matching, YAML persistence, and CredentialManager