### PR TITLE
feat: BaseController, cast(), file-backed stores, exclude_defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,84 @@ The extended dataclass notation includes semantic annotations as JSON-LD context
 
 More details see [example code](./tests/test_rdf.py)
 
+### BaseController
+
+Base mixin for controllers that extend `LinkedBaseModel` data classes. Controllers add runtime behavior (connections, archiving, state) without polluting the data model.
+
+```python
+from oold.model import BaseController, LinkedBaseModel
+
+class Robot(LinkedBaseModel):
+    name: str
+    joint_count: int = 6
+    connection_url: str = ""
+
+class RobotController(BaseController, Robot):
+    _connected: bool = False
+
+    def connect(self):
+        self._connected = True
+        print(f"Connected to {self.connection_url}")
+
+    def move(self, joint: int, angle: float):
+        if not self._connected:
+            raise RuntimeError("Not connected")
+        print(f"Moving joint {joint} to {angle} deg")
+
+ctrl = RobotController(name="arm-1", connection_url="tcp://192.168.1.10:5000")
+ctrl.connect()
+ctrl.move(1, 45.0)
+
+# Serialization includes model fields, strips controller state
+ctrl.to_json()  # {"name": "arm-1", "joint_count": 6, "connection_url": "tcp://..."}
+```
+
+Key features:
+- **Auto-detects the pure data model** from MRO - no manual configuration needed
+- **Serialization strips controller fields** - `to_json()` / `to_jsonld()` only include data model fields
+- **Type registry exclusion** - controllers don't replace their data model in the `_types` lookup, so backend resolution always returns the pure model class
+- **Multi-model support** - `Controller(ModelA, ModelB)` merges type arrays from both models
+
+### cast()
+
+Convert between model classes, preserving `__iris__` references:
+
+```python
+target = source.cast(TargetClass, remove_extra=True, none_to_default=True)
+
+# Or construct directly from another model instance:
+target = TargetClass(source, extra_field="value")
+```
+
+Parameters:
+- `none_to_default` - drop None/empty list attributes so the target uses its defaults
+- `remove_extra` - drop fields not defined on the target class
+- `silent` - suppress warnings about dropped fields (default: True)
+
+### Backends
+
+Built-in backends for entity persistence and resolution:
+
+| Backend | Storage | Query support |
+|---------|---------|---------------|
+| **SimpleDictDocumentStore** | In-memory dict, optional JSON file (`file_path`) | Filter by field |
+| **SqliteDocumentStore** | SQLite database (default `format=JSON`) | - |
+| **LocalSparqlBackend** | In-memory RDF graph (rdflib) | SPARQL |
+
+```python
+from oold.backend.document_store import SimpleDictDocumentStore
+from oold.backend.interface import StoreParam, SetResolverParam, set_resolver
+
+store = SimpleDictDocumentStore(file_path="./entities.json")
+set_resolver(SetResolverParam(iri="ex", resolver=store))
+
+# Store and resolve entities
+store.store(StoreParam(nodes={"ex:foo": foo}))
+loaded = MyModel["ex:foo"]  # resolves via registered backend
+```
+
+Custom backends implement the `Backend` interface (`resolve_iris`, `store_json_dicts`).
+
 ## Dev
 ```
 git clone https://github.com/OpenSemanticWorld/oold-python

--- a/src/oold/backend/document_store.py
+++ b/src/oold/backend/document_store.py
@@ -17,12 +17,31 @@ from oold.backend.interface import (
 
 
 class SimpleDictDocumentStore(Backend):
+    """In-memory document store backed by a Python dict.
+
+    Optionally persists to a JSON file if ``file_path`` is set.
+    On init, loads existing data from the file (if it exists).
+    On every store, writes the full dict back to disk.
+    """
+
     _store: Optional[Dict[str, dict]] = None
+    file_path: Optional[Union[Path, str]] = None
     format: LinkedDataFormat = LinkedDataFormat.JSON
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self._store = {}
+        if self.file_path is not None:
+            p = Path(self.file_path)
+            if p.exists():
+                with open(p) as f:
+                    self._store = json.load(f)
+
+    def _persist(self):
+        """Write store to file if file_path is set."""
+        if self.file_path is not None:
+            with open(self.file_path, "w") as f:
+                json.dump(self._store, f, indent=2)
 
     def resolve_iris(self, iris: List[str]) -> Dict[str, Dict]:
         jsonld_dicts = {}
@@ -33,6 +52,7 @@ class SimpleDictDocumentStore(Backend):
     def store_json_dicts(self, json_dicts: Dict[str, Dict]) -> StoreResult:
         for iri, json_dict in json_dicts.items():
             self._store[iri] = json_dict
+        self._persist()
         return StoreResult(success=True)
 
     def _filter(
@@ -93,6 +113,7 @@ class SimpleDictDocumentStore(Backend):
 
 class SqliteDocumentStore(Backend):
     db_path: Union[Path, str]
+    format: LinkedDataFormat = LinkedDataFormat.JSON
     persist_connection: bool = False
     _conn: Optional[sqlite3.Connection] = None
 
@@ -143,22 +164,22 @@ class SqliteDocumentStore(Backend):
             conn.close()
         return jsonld_dicts
 
-    def store_jsonld_dicts(self, jsonld_dicts: Dict[str, Dict]) -> StoreResult:
+    def _store_dicts(self, dicts: Dict[str, Dict]) -> StoreResult:
         conn = self._conn if self.persist_connection else sqlite3.connect(self.db_path)
         c = conn.cursor()
         c.executemany(
             """
             INSERT OR REPLACE INTO entities (id, data) VALUES (?, ?)
             """,
-            [
-                (iri, json.dumps(jsonld_dict))
-                for iri, jsonld_dict in jsonld_dicts.items()
-            ],
+            [(iri, json.dumps(d)) for iri, d in dicts.items()],
         )
         conn.commit()
         if not self.persist_connection:
             conn.close()
         return StoreResult(success=True)
+
+    def store_json_dicts(self, json_dicts: Dict[str, Dict]) -> StoreResult:
+        return self._store_dicts(json_dicts)
 
     def query():
         raise NotImplementedError()

--- a/src/oold/model/__init__.py
+++ b/src/oold/model/__init__.py
@@ -127,7 +127,16 @@ class LinkedBaseModelMetaClass(pydantic.main._model_construction.ModelMetaclass)
         finally:
             LinkedBaseModelMetaClass._constructing = False
 
-        if hasattr(cls, "get_cls_iri"):
+        # Register type IRI mapping, but skip controller classes
+        # (they extend data models but should not replace them in
+        # the type lookup table).
+        _is_ctrl = any(
+            b.__module__ == "oold.model" and b.__name__ == "BaseController"
+            for b in cls.__mro__
+        )
+        if _is_ctrl:
+            pass
+        elif hasattr(cls, "get_cls_iri"):
             iri = cls.get_cls_iri()
             if iri is not None:
                 if isinstance(iri, list):
@@ -459,6 +468,14 @@ class LinkedBaseModel(
             )
 
     def __init__(self, *a, **kw):
+        # Accept a model instance as first positional arg:
+        # TargetModel(source_model, extra_field=value)
+        if a and isinstance(a[0], BaseModel):
+            result = a[0].cast(type(self), **kw)
+            kw = result.model_dump()
+            kw["__iris__"] = getattr(result, "__iris__", {})
+            a = ()
+
         if "__iris__" not in kw:
             kw["__iris__"] = {}
 
@@ -883,6 +900,42 @@ class LinkedBaseModel(
             d = self.remove_none(d)
         return json.dumps(d, **dumps_kwargs)
 
+    def cast(self, cls, remove_extra=False, silent=True, **kwargs):
+        """Cast this instance to a different model class.
+
+        Parameters
+        ----------
+        cls
+            Target class to cast to.
+        remove_extra
+            If True, drop fields not defined on the target class.
+        silent
+            If True, suppress warnings about dropped fields.
+        kwargs
+            Additional fields to set on the new instance.
+        """
+        data = {**self.model_dump(), **kwargs}
+        if remove_extra:
+            target_fields = set()
+            if hasattr(cls, "model_fields"):
+                target_fields = set(cls.model_fields.keys())
+            elif hasattr(cls, "__fields__"):
+                target_fields = set(cls.__fields__.keys())
+            if target_fields:
+                extra = [k for k in data if k not in target_fields]
+                for k in extra:
+                    del data[k]
+        if "type" in data:
+            del data["type"]
+        # Carry over __iris__ (range field references)
+        if hasattr(self, "__iris__"):
+            iris = dict(self.__iris__)
+            if "__iris__" in data:
+                iris.update(data["__iris__"])
+            data["__iris__"] = iris
+        result = cls(**data)
+        return result
+
     def to_jsonld(self) -> Dict:
         """Return the RDF representation of the object as JSON-LD."""
         return export_jsonld(self, BaseModel)
@@ -923,3 +976,114 @@ class LinkedBaseModel(
     #     #     by_alias, ref_template, schema_generator, mode
     #     # )
     #     return cls.export_schema(cls)
+
+
+class BaseController:
+    """Base mixin for controllers that extend LinkedBaseModel data classes.
+
+    Overrides to_json() and to_jsonld() to serialize only the pure data
+    model fields, stripping controller-only fields (e.g. archive_database,
+    auto_archive, connection state).
+
+    The data model class is auto-detected from the MRO: the first
+    LinkedBaseModel subclass that is not also a BaseController subclass.
+
+    Controllers are excluded from oold's type IRI registry (_types) so
+    they don't replace their pure data model counterparts during
+    backend resolution.
+    """
+
+    def _get_data_model_cls(self):
+        """Auto-detect the pure data model class from the MRO.
+
+        Finds all direct LinkedBaseModel bases that are not controllers.
+        If there are multiple, creates a dynamic union class combining
+        them (e.g. Controller(ModelA, ModelB) -> _ModelA_ModelB).
+        """
+
+        def _is_data_model(cls):
+            return (
+                cls is not type(self)
+                and cls.__name__
+                not in (
+                    "LinkedBaseModel",
+                    "_LinkedBaseModel",
+                    "BaseController",
+                    "GenericLinkedBaseModel",
+                    "BaseModel",
+                    "Representation",
+                )
+                and hasattr(cls, "to_json")
+                and hasattr(cls, "from_json")
+                and not issubclass(cls, BaseController)
+            )
+
+        model_bases = []
+        for cls in type(self).__mro__:
+            if _is_data_model(cls):
+                if not any(issubclass(m, cls) for m in model_bases):
+                    model_bases.append(cls)
+        if len(model_bases) == 0:
+            return None
+        if len(model_bases) == 1:
+            return model_bases[0]
+        name = "_".join(b.__name__ for b in model_bases)
+        union_cls = type(name, tuple(model_bases), {})
+        union_cls._union_bases = model_bases
+        return union_cls
+
+    def _get_model_bases(self):
+        """Return the list of pure data model base classes."""
+        model_cls = self._get_data_model_cls()
+        if model_cls is None:
+            return []
+        if hasattr(model_cls, "_union_bases"):
+            return model_cls._union_bases
+        return [model_cls]
+
+    def _collect_type_array(self):
+        """Collect merged type array from all pure data model bases."""
+        bases = self._get_model_bases()
+        if len(bases) <= 1:
+            return None
+        merged = []
+        for base in bases:
+            field = None
+            if hasattr(base, "model_fields"):
+                field = base.model_fields.get("type")
+            elif hasattr(base, "__fields__"):
+                field = base.__fields__.get("type")
+            default = getattr(field, "default", None) if field else None
+            if isinstance(default, list):
+                for t in default:
+                    if t not in merged:
+                        merged.append(t)
+            elif isinstance(default, str) and default not in merged:
+                merged.append(default)
+        return merged if merged else None
+
+    def _cast_to_pure(self, model_cls):
+        """Cast self to the pure model class."""
+        return self.cast(model_cls, remove_extra=True)
+
+    def to_json(self, **kwargs):
+        model_cls = self._get_data_model_cls()
+        if model_cls is not None:
+            merged_types = self._collect_type_array()
+            pure = self._cast_to_pure(model_cls)
+            data = pure.to_json(**kwargs)
+            if merged_types:
+                data["type"] = merged_types
+            return data
+        return super().to_json(**kwargs)
+
+    def to_jsonld(self):
+        model_cls = self._get_data_model_cls()
+        if model_cls is not None:
+            merged_types = self._collect_type_array()
+            pure = self._cast_to_pure(model_cls)
+            data = pure.to_jsonld()
+            if merged_types:
+                data["type"] = merged_types
+            return data
+        return super().to_jsonld()

--- a/src/oold/model/__init__.py
+++ b/src/oold/model/__init__.py
@@ -892,9 +892,22 @@ class LinkedBaseModel(
         """Constructs a model instance from a JSON-LD representation."""
         return import_jsonld(BaseModel, LinkedBaseModel, cls, jsonld, _types)
 
-    def to_json(self) -> Dict:
-        """Return the JSON representation of the object."""
-        return json.loads(self.model_dump_json(exclude_none=True))
+    def to_json(self, exclude_defaults: bool = False) -> Dict:
+        """Return the JSON representation of the object.
+
+        Parameters
+        ----------
+        exclude_defaults
+            If True, fields with default values are excluded from the
+            output. Useful for compact storage where defaults can be
+            re-populated on deserialization via from_json().
+        """
+        return json.loads(
+            self.model_dump_json(
+                exclude_none=True,
+                exclude_defaults=exclude_defaults,
+            )
+        )
 
     @classmethod
     def from_json(cls, data: Dict) -> "LinkedBaseModel":

--- a/src/oold/model/__init__.py
+++ b/src/oold/model/__init__.py
@@ -622,11 +622,8 @@ class LinkedBaseModel(
 
     def __setattr__(self, name, value, internal=False):
         # print("__setattr__", name, value)
-        if not internal and name not in [
-            "__dict__",
-            "__pydantic_private__",
-            "__iris__",
-        ]:
+        # Only apply range handling for declared model fields
+        if not internal and name in self.model_fields:
             value = self._handle_value(name, value)
 
         return super().__setattr__(name, value)

--- a/src/oold/model/__init__.py
+++ b/src/oold/model/__init__.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -109,6 +110,8 @@ _types: Dict[str, pydantic.main._model_construction.ModelMetaclass] = {}
 
 
 M = TypeVar("M", bound="LinkedBaseModel")
+
+_logger = logging.getLogger(__name__)
 
 
 # pydantic v2
@@ -900,13 +903,23 @@ class LinkedBaseModel(
             d = self.remove_none(d)
         return json.dumps(d, **dumps_kwargs)
 
-    def cast(self, cls, remove_extra=False, silent=True, **kwargs):
+    def cast(
+        self,
+        cls,
+        none_to_default=False,
+        remove_extra=False,
+        silent=True,
+        **kwargs,
+    ):
         """Cast this instance to a different model class.
 
         Parameters
         ----------
         cls
             Target class to cast to.
+        none_to_default
+            If True, attributes that are None or empty lists are
+            removed so the target class uses its defaults.
         remove_extra
             If True, drop fields not defined on the target class.
         silent
@@ -915,6 +928,20 @@ class LinkedBaseModel(
             Additional fields to set on the new instance.
         """
         data = {**self.model_dump(), **kwargs}
+        none_args = []
+        if none_to_default:
+            reduced = {}
+            for k, v in data.items():
+                if v is None:
+                    none_args.append(k)
+                elif isinstance(v, list) and (
+                    len(v) == 0 or all(item is None for item in v)
+                ):
+                    none_args.append(k)
+                else:
+                    reduced[k] = v
+            data = reduced
+        extra_args = []
         if remove_extra:
             target_fields = set()
             if hasattr(cls, "model_fields"):
@@ -922,9 +949,14 @@ class LinkedBaseModel(
             elif hasattr(cls, "__fields__"):
                 target_fields = set(cls.__fields__.keys())
             if target_fields:
-                extra = [k for k in data if k not in target_fields]
-                for k in extra:
+                extra_args = [k for k in data if k not in target_fields]
+                for k in extra_args:
                     del data[k]
+        if not silent:
+            if none_to_default and none_args:
+                _logger.warning("Removed None/empty attributes: %s", none_args)
+            if remove_extra and extra_args:
+                _logger.warning("Removed extra attributes: %s", extra_args)
         if "type" in data:
             del data["type"]
         # Carry over __iris__ (range field references)
@@ -933,8 +965,11 @@ class LinkedBaseModel(
             if "__iris__" in data:
                 iris.update(data["__iris__"])
             data["__iris__"] = iris
-        result = cls(**data)
-        return result
+        return cls(**data)
+
+    def cast_none_to_default(self, cls, **kwargs):
+        """Cast to target class, dropping None/empty list attributes."""
+        return self.cast(cls, none_to_default=True, **kwargs)
 
     def to_jsonld(self) -> Dict:
         """Return the RDF representation of the object as JSON-LD."""

--- a/src/oold/model/v1/__init__.py
+++ b/src/oold/model/v1/__init__.py
@@ -756,9 +756,22 @@ class LinkedBaseModel(_LinkedBaseModel):
         """Constructs a model instance from a JSON-LD representation."""
         return import_jsonld(BaseModel, LinkedBaseModel, cls, jsonld, _types)
 
-    def to_json(self) -> Dict:
-        """Return the JSON representation of the object as dict."""
-        return json.loads(self.json(exclude_none=True))
+    def to_json(self, exclude_defaults: bool = False) -> Dict:
+        """Return the JSON representation of the object as dict.
+
+        Parameters
+        ----------
+        exclude_defaults
+            If True, fields with default values are excluded from the
+            output. Useful for compact storage where defaults can be
+            re-populated on deserialization via from_json().
+        """
+        return json.loads(
+            self.json(
+                exclude_none=True,
+                exclude_defaults=exclude_defaults,
+            )
+        )
 
     @classmethod
     def from_json(cls, json_dict: Dict) -> "LinkedBaseModel":

--- a/src/oold/model/v1/__init__.py
+++ b/src/oold/model/v1/__init__.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -111,6 +112,8 @@ _types: Dict[str, pydantic.v1.main.ModelMetaclass] = {}
 
 
 M = TypeVar("M", bound="LinkedBaseModel")
+
+_logger = logging.getLogger(__name__)
 
 
 # pydantic v1
@@ -762,17 +765,58 @@ class LinkedBaseModel(_LinkedBaseModel):
             d = self.remove_none(d)
         return json.dumps(d, **dumps_kwargs)
 
-    def cast(self, cls, remove_extra=False, silent=True, **kwargs):
-        """Cast this instance to a different model class."""
+    def cast(
+        self,
+        cls,
+        none_to_default=False,
+        remove_extra=False,
+        silent=True,
+        **kwargs,
+    ):
+        """Cast this instance to a different model class.
+
+        Parameters
+        ----------
+        cls
+            Target class to cast to.
+        none_to_default
+            If True, attributes that are None or empty lists are
+            removed so the target class uses its defaults.
+        remove_extra
+            If True, drop fields not defined on the target class.
+        silent
+            If True, suppress warnings about dropped fields.
+        kwargs
+            Additional fields to set on the new instance.
+        """
         data = {**self.dict(), **kwargs}
+        none_args = []
+        if none_to_default:
+            reduced = {}
+            for k, v in data.items():
+                if v is None:
+                    none_args.append(k)
+                elif isinstance(v, list) and (
+                    len(v) == 0 or all(item is None for item in v)
+                ):
+                    none_args.append(k)
+                else:
+                    reduced[k] = v
+            data = reduced
+        extra_args = []
         if remove_extra:
             target_fields = set()
             if hasattr(cls, "__fields__"):
                 target_fields = set(cls.__fields__.keys())
             if target_fields:
-                extra = [k for k in data if k not in target_fields]
-                for k in extra:
+                extra_args = [k for k in data if k not in target_fields]
+                for k in extra_args:
                     del data[k]
+        if not silent:
+            if none_to_default and none_args:
+                _logger.warning("Removed None/empty attributes: %s", none_args)
+            if remove_extra and extra_args:
+                _logger.warning("Removed extra attributes: %s", extra_args)
         if "type" in data:
             del data["type"]
         if hasattr(self, "__iris__"):
@@ -781,6 +825,10 @@ class LinkedBaseModel(_LinkedBaseModel):
                 iris.update(data["__iris__"])
             data["__iris__"] = iris
         return cls(**data)
+
+    def cast_none_to_default(self, cls, **kwargs):
+        """Cast to target class, dropping None/empty list attributes."""
+        return self.cast(cls, none_to_default=True, **kwargs)
 
     def to_jsonld(self) -> Dict:
         """Return the RDF representation of the object as JSON-LD."""

--- a/src/oold/model/v1/__init__.py
+++ b/src/oold/model/v1/__init__.py
@@ -129,7 +129,14 @@ class LinkedBaseModelMetaClass(pydantic.v1.main.ModelMetaclass):
         finally:
             LinkedBaseModelMetaClass._constructing = False
 
-        if hasattr(cls, "get_cls_iri"):
+        # Register type IRI mapping, but skip controller classes
+        _is_ctrl = any(
+            b.__module__ == "oold.model" and b.__name__ == "BaseController"
+            for b in cls.__mro__
+        )
+        if _is_ctrl:
+            pass
+        elif hasattr(cls, "get_cls_iri"):
             iri = cls.get_cls_iri()
             if iri is not None:
                 if isinstance(iri, list):
@@ -382,6 +389,14 @@ class LinkedBaseModel(_LinkedBaseModel):
             return super().parse_obj(obj)
 
     def __init__(self, *a, **kw):
+        # Accept a model instance as first positional arg:
+        # TargetModel(source_model, extra_field=value)
+        if a and isinstance(a[0], BaseModel):
+            result = a[0].cast(type(self), **kw)
+            kw = result.dict()
+            kw["__iris__"] = getattr(result, "__iris__", {})
+            a = ()
+
         if "__iris__" not in kw:
             kw["__iris__"] = {}
 
@@ -747,6 +762,26 @@ class LinkedBaseModel(_LinkedBaseModel):
             d = self.remove_none(d)
         return json.dumps(d, **dumps_kwargs)
 
+    def cast(self, cls, remove_extra=False, silent=True, **kwargs):
+        """Cast this instance to a different model class."""
+        data = {**self.dict(), **kwargs}
+        if remove_extra:
+            target_fields = set()
+            if hasattr(cls, "__fields__"):
+                target_fields = set(cls.__fields__.keys())
+            if target_fields:
+                extra = [k for k in data if k not in target_fields]
+                for k in extra:
+                    del data[k]
+        if "type" in data:
+            del data["type"]
+        if hasattr(self, "__iris__"):
+            iris = dict(self.__iris__)
+            if "__iris__" in data:
+                iris.update(data["__iris__"])
+            data["__iris__"] = iris
+        return cls(**data)
+
     def to_jsonld(self) -> Dict:
         """Return the RDF representation of the object as JSON-LD."""
         return export_jsonld(self, BaseModel)
@@ -777,3 +812,7 @@ class LinkedBaseModel(_LinkedBaseModel):
     def from_json(cls, json_dict: Dict) -> "LinkedBaseModel":
         """Constructs a model instance from a JSON representation."""
         return import_json(BaseModel, LinkedBaseModel, cls, json_dict, _types)
+
+
+# Re-export BaseController from v2 module (it's a plain class, no Pydantic dep)
+from oold.model import BaseController  # noqa: E402, F401

--- a/src/oold/model/v1/__init__.py
+++ b/src/oold/model/v1/__init__.py
@@ -538,11 +538,8 @@ class LinkedBaseModel(_LinkedBaseModel):
 
     def __setattr__(self, name, value, internal=False):
         # print("__setattr__", name, value)
-        if not internal and name not in [
-            "__dict__",
-            "__pydantic_private__",
-            "__iris__",
-        ]:
+        # Only apply range handling for declared model fields
+        if not internal and name in self.__fields__:
             value = self._handle_value(name, value)
 
         return super().__setattr__(name, value)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -124,6 +124,46 @@ def test_local_sparql_store(benchmark):
         _run(store)
 
 
+def test_simple_dict_file_persistence(tmp_path):
+    """Test SimpleDictDocumentStore with file_path for persistence."""
+    from pydantic import ConfigDict
+
+    from oold.model import LinkedBaseModel
+
+    class Item(LinkedBaseModel):
+        model_config = ConfigDict(
+            json_schema_extra={
+                "@context": {"ex": "https://example.com/", "name": "ex:name"},
+                "$id": "https://example.com/Item",
+            }
+        )
+        name: str
+
+        def get_iri(self):
+            return "ex:" + self.name
+
+    file_path = tmp_path / "store.json"
+
+    # Store
+    store1 = SimpleDictDocumentStore(file_path=file_path)
+    item = Item(name="Foo")
+    store1.store(StoreParam(nodes={item.get_iri(): item}))
+    assert file_path.exists()
+
+    # Load in a new store instance
+    store2 = SimpleDictDocumentStore(file_path=file_path)
+    result = store2.resolve(ResolveParam(iris=["ex:Foo"], model_cls=Item))
+    loaded = result.nodes["ex:Foo"]
+    assert loaded.name == "Foo"
+
+
+def test_simple_dict_file_no_file():
+    """SimpleDictDocumentStore without file_path works in-memory only."""
+    store = SimpleDictDocumentStore()
+    assert store.file_path is None
+    assert store._store == {}
+
+
 if __name__ == "__main__":
     test_simple_dict_document_store(None)
     test_sqlite_document_store(None)

--- a/tests/test_base_controller.py
+++ b/tests/test_base_controller.py
@@ -1,0 +1,101 @@
+"""Tests for BaseController serialization and model detection."""
+
+from typing import List, Optional
+
+from pydantic import ConfigDict
+
+from oold.model import BaseController, LinkedBaseModel
+
+# -- Test models --
+
+
+class ModelA(LinkedBaseModel):
+    model_config = ConfigDict(json_schema_extra={"title": "ModelA"})
+    type: Optional[List[str]] = ["Category:OSWModelA"]
+    field_a: str = "default_a"
+
+
+class ModelB(LinkedBaseModel):
+    model_config = ConfigDict(json_schema_extra={"title": "ModelB"})
+    type: Optional[List[str]] = ["Category:OSWModelB"]
+    field_b: str = "default_b"
+
+
+# -- Single model base --
+
+
+class SingleController(BaseController, ModelA):
+    controller_field: str = "ctrl_value"
+
+
+def test_auto_detect_single_base():
+    ctrl = SingleController(name="test", label=[])
+    model_cls = ctrl._get_data_model_cls()
+    assert model_cls is ModelA
+
+
+def test_to_json_strips_controller_fields():
+    ctrl = SingleController(name="test", label=[])
+    j = ctrl.to_json()
+    assert "field_a" in j
+    assert "controller_field" not in j
+
+
+def test_to_json_preserves_type():
+    ctrl = SingleController(name="test", label=[])
+    j = ctrl.to_json()
+    assert j["type"] == ["Category:OSWModelA"]
+
+
+def test_round_trip_single():
+    ctrl = SingleController(name="test", label=[])
+    j = ctrl.to_json()
+    restored = ModelA.from_json(j)
+    assert restored.field_a == "default_a"
+
+
+# -- Multiple model bases --
+
+
+class MultiController(BaseController, ModelA, ModelB):
+    multi_ctrl_field: str = "multi_ctrl"
+
+
+def test_auto_detect_multi_base():
+    ctrl = MultiController(name="test", label=[])
+    model_cls = ctrl._get_data_model_cls()
+    assert model_cls is not None
+    assert hasattr(model_cls, "_union_bases")
+    assert ModelA in model_cls._union_bases
+    assert ModelB in model_cls._union_bases
+
+
+def test_multi_to_json_strips_controller_fields():
+    ctrl = MultiController(name="test", label=[])
+    j = ctrl.to_json()
+    assert "field_a" in j
+    assert "multi_ctrl_field" not in j
+
+
+def test_multi_to_json_merges_type_arrays():
+    ctrl = MultiController(name="test", label=[])
+    j = ctrl.to_json()
+    assert "Category:OSWModelA" in j["type"]
+    assert "Category:OSWModelB" in j["type"]
+    assert len(j["type"]) == 2
+
+
+def test_multi_get_model_bases():
+    ctrl = MultiController(name="test", label=[])
+    bases = ctrl._get_model_bases()
+    assert len(bases) == 2
+    assert ModelA in bases
+    assert ModelB in bases
+
+
+# -- Edge: no model base --
+
+
+def test_base_controller_is_plain_class():
+    """BaseController is not a LinkedBaseModel subclass."""
+    assert not issubclass(BaseController, LinkedBaseModel)

--- a/tests/test_oold.py
+++ b/tests/test_oold.py
@@ -274,6 +274,60 @@ def test_nested_iri_serialization(pydantic_version):
     assert item0.get_raw("nonexistent") is None  # missing field
 
 
+def _run_cast_tests(pydantic_version="v2"):
+    if pydantic_version == "v1":
+        from oold.model.v1 import LinkedBaseModel
+    else:
+        from oold.model import LinkedBaseModel
+
+    class ModelA(LinkedBaseModel):
+        value: float
+        name: str = "default"
+
+    class ModelB(LinkedBaseModel):
+        value: float
+        extra: str = "ext"
+
+    class Narrow(LinkedBaseModel):
+        value: float
+
+    # cast to same class
+    a = ModelA(value=42.0, name="hello")
+    a2 = a.cast(ModelA)
+    assert a2.value == 42.0
+    assert a2.name == "hello"
+
+    # cast to different class with kwargs
+    b = ModelA(value=10.0).cast(ModelB, extra="custom")
+    assert b.value == 10.0
+    assert b.extra == "custom"
+
+    # cast with remove_extra
+    wide = ModelA(value=1.0, name="test")
+    n = wide.cast(Narrow, remove_extra=True)
+    assert n.value == 1.0
+
+    # constructor from model instance: ModelB(model_a, extra="x")
+    a3 = ModelA(value=5.0, name="src")
+    b2 = ModelB(a3, extra="ctor")
+    assert b2.value == 5.0
+    assert b2.extra == "ctor"
+
+    # constructor override: kwargs take precedence
+    a4 = ModelA(value=5.0, name="src")
+    a5 = ModelA(a4, name="overridden")
+    assert a5.name == "overridden"
+    assert a5.value == 5.0
+
+
+def test_cast_v1():
+    _run_cast_tests("v1")
+
+
+def test_cast_v2():
+    _run_cast_tests("v2")
+
+
 if __name__ == "__main__":
     _run("v1")
     _run("v2")

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,83 @@
+"""Tests for to_json / from_json serialization."""
+
+import pytest
+
+
+def _get_models(pydantic_version):
+    if pydantic_version == "v2":
+        from oold.model import LinkedBaseModel
+    else:
+        from oold.model.v1 import LinkedBaseModel
+    return LinkedBaseModel
+
+
+@pytest.mark.parametrize("pydantic_version", ["v1", "v2"])
+def test_to_json_returns_dict(pydantic_version):
+    LinkedBaseModel = _get_models(pydantic_version)
+
+    class Foo(LinkedBaseModel):
+        value: float
+        name: str = "default"
+
+    obj = Foo(value=42.0)
+    result = obj.to_json()
+    assert isinstance(result, dict)
+    assert result["value"] == 42.0
+    assert result["name"] == "default"
+
+
+@pytest.mark.parametrize("pydantic_version", ["v1", "v2"])
+def test_to_json_exclude_defaults(pydantic_version):
+    LinkedBaseModel = _get_models(pydantic_version)
+
+    class Foo(LinkedBaseModel):
+        value: float
+        name: str = "default"
+
+    obj = Foo(value=42.0)
+    result = obj.to_json(exclude_defaults=True)
+    assert "value" in result
+    assert "name" not in result
+
+
+@pytest.mark.parametrize("pydantic_version", ["v1", "v2"])
+def test_from_json_restores_defaults(pydantic_version):
+    LinkedBaseModel = _get_models(pydantic_version)
+
+    class Foo(LinkedBaseModel):
+        value: float
+        name: str = "default"
+
+    compact = {"value": 42.0}
+    restored = Foo.from_json(compact)
+    assert restored.value == 42.0
+    assert restored.name == "default"
+
+
+@pytest.mark.parametrize("pydantic_version", ["v1", "v2"])
+def test_to_json_exclude_defaults_false(pydantic_version):
+    LinkedBaseModel = _get_models(pydantic_version)
+
+    class Foo(LinkedBaseModel):
+        value: float
+        name: str = "default"
+
+    obj = Foo(value=42.0)
+    full = obj.to_json(exclude_defaults=False)
+    assert full["name"] == "default"
+    assert full["value"] == 42.0
+
+
+@pytest.mark.parametrize("pydantic_version", ["v1", "v2"])
+def test_to_json_excludes_none(pydantic_version):
+    LinkedBaseModel = _get_models(pydantic_version)
+
+    from typing import Optional
+
+    class Foo(LinkedBaseModel):
+        value: float
+        label: Optional[str] = None
+
+    obj = Foo(value=1.0)
+    result = obj.to_json()
+    assert "label" not in result


### PR DESCRIPTION
## Summary
- Add `BaseController` mixin for controllers that extend data models without polluting the type registry
- Add `cast()` / `cast_none_to_default()` to `LinkedBaseModel` for cross-model conversion with `__iris__` carry-over
- Add `exclude_defaults` parameter to `to_json()` (v1 + v2)
- `SimpleDictDocumentStore`: add `file_path` for JSON file persistence
- `SqliteDocumentStore`: default `format=JSON`, add `store_json_dicts`
- Restrict `__setattr__` range handling to declared model fields only
- Update README with BaseController, cast(), and Backends documentation