### PR TITLE
fix: preserve inline objects through cast() and dict() serialization

### DIFF
--- a/src/oold/generator.py
+++ b/src/oold/generator.py
@@ -155,6 +155,18 @@ class Generator:
                         r"(from pydantic import)", "from pydantic.v1 import", content
                     )
 
+                # fix unserializable defaults from datamodel-code-generator
+                # when allOf merges a property override (e.g. hidden:true) with
+                # a parent field typed as a complex model, the default becomes
+                # an unserializable sentinel: lambda :Foo.parse_obj(<object ...>)
+                content = re.sub(
+                    r"default_factory=lambda\s*:.*<object object at 0x[0-9a-fA-F]+>\)",
+                    "default=None)",
+                    content,
+                )
+                # fix lambda formatting (space before colon breaks black)
+                content = content.replace("lambda :", "lambda:")
+
                 # write the content to the file
                 with open(output, "w", encoding="utf-8") as f:
                     f.write(content)

--- a/src/oold/model/__init__.py
+++ b/src/oold/model/__init__.py
@@ -474,8 +474,10 @@ class LinkedBaseModel(
         # Accept a model instance as first positional arg:
         # TargetModel(source_model, extra_field=value)
         if a and isinstance(a[0], BaseModel):
-            result = a[0].cast(type(self), **kw)
-            kw = result.model_dump()
+            source = a[0]
+            result = source.cast(type(self), **kw)
+            kw = super(LinkedBaseModel, result).model_dump()
+            LinkedBaseModel._recursive_object_to_iri(kw, source)
             kw["__iris__"] = getattr(result, "__iris__", {})
             a = ()
 

--- a/src/oold/model/__init__.py
+++ b/src/oold/model/__init__.py
@@ -1004,7 +1004,10 @@ class LinkedBaseModel(
         # because their model value is None (the IRI lives in __iris__)
         if hasattr(self, "__iris__"):
             for field_name, iri in self.__iris__.items():
-                if field_name not in result and iri is not None:
+                if iri is None:
+                    continue
+                existing = result.get(field_name)
+                if existing is None or existing == [] or existing == {}:
                     result[field_name] = iri
         return result
 
@@ -1113,15 +1116,24 @@ class BaseController:
         return self.cast(model_cls, remove_extra=True)
 
     def to_json(self, **kwargs):
+        # Serialize with LinkedBaseModel.to_json (includes __iris__),
+        # then strip controller-only fields
+        data = super().to_json(**kwargs)
         model_cls = self._get_data_model_cls()
         if model_cls is not None:
             merged_types = self._collect_type_array()
-            pure = self._cast_to_pure(model_cls)
-            data = pure.to_json(**kwargs)
             if merged_types:
                 data["type"] = merged_types
-            return data
-        return super().to_json(**kwargs)
+            # Remove fields not in the pure data model
+            model_fields = set(
+                model_cls.model_fields.keys()
+                if hasattr(model_cls, "model_fields")
+                else getattr(model_cls, "__fields__", {}).keys()
+            )
+            for key in list(data.keys()):
+                if key not in model_fields and key not in ("type", "@context"):
+                    del data[key]
+        return data
 
     def to_jsonld(self):
         model_cls = self._get_data_model_cls()

--- a/src/oold/model/__init__.py
+++ b/src/oold/model/__init__.py
@@ -924,7 +924,12 @@ class LinkedBaseModel(
         kwargs
             Additional fields to set on the new instance.
         """
-        data = {**self.model_dump(), **kwargs}
+        # Use raw Pydantic model_dump (without _object_to_iri which replaces
+        # inline objects with IRIs). Only inject __iris__ for nested objects
+        # so their range-field IRIs survive reconstruction.
+        raw = super().model_dump()
+        self._recursive_object_to_iri(raw, self)
+        data = {**raw, **kwargs}
         none_args = []
         if none_to_default:
             reduced = {}
@@ -987,12 +992,19 @@ class LinkedBaseModel(
             output. Useful for compact storage where defaults can be
             re-populated on deserialization via from_json().
         """
-        return json.loads(
+        result = json.loads(
             self.model_dump_json(
                 exclude_none=True,
                 exclude_defaults=exclude_defaults,
             )
         )
+        # Re-inject IRI-only fields from __iris__ that were excluded
+        # because their model value is None (the IRI lives in __iris__)
+        if hasattr(self, "__iris__"):
+            for field_name, iri in self.__iris__.items():
+                if field_name not in result and iri is not None:
+                    result[field_name] = iri
+        return result
 
     @classmethod
     def from_json(cls, data: Dict) -> "LinkedBaseModel":

--- a/src/oold/model/v1/__init__.py
+++ b/src/oold/model/v1/__init__.py
@@ -396,7 +396,10 @@ class LinkedBaseModel(_LinkedBaseModel):
         # TargetModel(source_model, extra_field=value)
         if a and isinstance(a[0], BaseModel):
             result = a[0].cast(type(self), **kw)
-            kw = result.dict()
+            # Use raw Pydantic dict to preserve inline objects
+            # (our dict() override replaces them with IRIs)
+            kw = super(LinkedBaseModel, result).dict()
+            result._recursive_object_to_iri(kw, result)
             kw["__iris__"] = getattr(result, "__iris__", {})
             a = ()
 
@@ -716,6 +719,21 @@ class LinkedBaseModel(_LinkedBaseModel):
                 model_value._object_to_iri(value)
                 LinkedBaseModel._recursive_object_to_iri(value, model_value)
 
+    def dict(self, **kwargs):
+        """Override Pydantic v1 dict() to include __iris__ values.
+
+        Ensures IRI-only fields (value=None, IRI in __iris__) are included
+        in the output, including for nested model objects.
+        """
+        exclude_none = kwargs.pop("exclude_none", False)
+        kwargs["exclude_none"] = False
+        d = super().dict(**kwargs)
+        self._object_to_iri(d)
+        self._recursive_object_to_iri(d, self)
+        if exclude_none:
+            d = self.remove_none(d)
+        return d
+
     # pydantic v1
     def json(
         self,
@@ -786,7 +804,12 @@ class LinkedBaseModel(_LinkedBaseModel):
         kwargs
             Additional fields to set on the new instance.
         """
-        data = {**self.dict(), **kwargs}
+        # Use raw Pydantic dict (without _object_to_iri which replaces
+        # inline objects with IRIs). Only inject __iris__ for nested objects
+        # so their range-field IRIs survive reconstruction.
+        raw = super().dict()
+        self._recursive_object_to_iri(raw, self)
+        data = {**raw, **kwargs}
         none_args = []
         if none_to_default:
             reduced = {}
@@ -846,12 +869,19 @@ class LinkedBaseModel(_LinkedBaseModel):
             output. Useful for compact storage where defaults can be
             re-populated on deserialization via from_json().
         """
-        return json.loads(
+        result = json.loads(
             self.json(
                 exclude_none=True,
                 exclude_defaults=exclude_defaults,
             )
         )
+        # Re-inject IRI-only fields from __iris__ that were excluded
+        # because their model value is None (the IRI lives in __iris__)
+        if hasattr(self, "__iris__"):
+            for field_name, iri in self.__iris__.items():
+                if field_name not in result and iri is not None:
+                    result[field_name] = iri
+        return result
 
     @classmethod
     def from_json(cls, json_dict: Dict) -> "LinkedBaseModel":

--- a/src/oold/model/v1/__init__.py
+++ b/src/oold/model/v1/__init__.py
@@ -395,11 +395,14 @@ class LinkedBaseModel(_LinkedBaseModel):
         # Accept a model instance as first positional arg:
         # TargetModel(source_model, extra_field=value)
         if a and isinstance(a[0], BaseModel):
-            result = a[0].cast(type(self), **kw)
+            source = a[0]
+            result = source.cast(type(self), **kw)
             # Use raw Pydantic dict to preserve inline objects
-            # (our dict() override replaces them with IRIs)
+            # (our dict() override replaces them with IRIs).
+            # Inject nested IRIs from the SOURCE (not result, which
+            # may have lost nested __iris__ during cast reconstruction).
             kw = super(LinkedBaseModel, result).dict()
-            result._recursive_object_to_iri(kw, result)
+            LinkedBaseModel._recursive_object_to_iri(kw, source)
             kw["__iris__"] = getattr(result, "__iris__", {})
             a = ()
 

--- a/src/oold/model/v1/__init__.py
+++ b/src/oold/model/v1/__init__.py
@@ -882,7 +882,10 @@ class LinkedBaseModel(_LinkedBaseModel):
         # because their model value is None (the IRI lives in __iris__)
         if hasattr(self, "__iris__"):
             for field_name, iri in self.__iris__.items():
-                if field_name not in result and iri is not None:
+                if iri is None:
+                    continue
+                existing = result.get(field_name)
+                if existing is None or existing == [] or existing == {}:
                     result[field_name] = iri
         return result
 

--- a/tests/test_base_controller.py
+++ b/tests/test_base_controller.py
@@ -2,7 +2,7 @@
 
 from typing import List, Optional
 
-from pydantic import ConfigDict
+from pydantic import ConfigDict, Field
 
 from oold.model import BaseController, LinkedBaseModel
 
@@ -99,3 +99,86 @@ def test_multi_get_model_bases():
 def test_base_controller_is_plain_class():
     """BaseController is not a LinkedBaseModel subclass."""
     assert not issubclass(BaseController, LinkedBaseModel)
+
+
+# -- Range field preservation --
+
+
+class Parent(LinkedBaseModel):
+    model_config = ConfigDict(
+        json_schema_extra={"title": "Parent"},
+    )
+    type: Optional[List[str]] = ["Category:OSWParent"]
+    children: Optional[List["Child"]] = None
+    ref: Optional[str] = Field(None, json_schema_extra={"range": "Category:Target"})
+
+
+class Child(LinkedBaseModel):
+    model_config = ConfigDict(
+        json_schema_extra={"title": "Child"},
+    )
+    value: int = 0
+    ref: Optional[str] = Field(
+        None, json_schema_extra={"range": "Category:ChildTarget"}
+    )
+
+
+class ParentController(BaseController, Parent):
+    ctrl_field: str = "ctrl"
+
+
+def test_to_json_preserves_range_iris():
+    """to_json() preserves IRI references on range fields."""
+    ctrl = ParentController(
+        name="test",
+        label=[],
+        ref="ex:target1",
+        children=[Child(value=1, ref="ex:child_target")],
+    )
+    j = ctrl.to_json()
+    assert j["ref"] == "ex:target1"
+    assert "ctrl_field" not in j
+
+
+def test_to_json_preserves_nested_range_iris():
+    """to_json() preserves IRI references on nested object range fields."""
+    ctrl = ParentController(
+        name="test",
+        label=[],
+        children=[Child(value=1, ref="ex:child_target")],
+    )
+    j = ctrl.to_json()
+    assert "children" in j
+    assert len(j["children"]) == 1
+    assert j["children"][0]["ref"] == "ex:child_target"
+
+
+def test_controller_round_trip():
+    """Controller -> to_json -> from_json preserves all data."""
+    ctrl = ParentController(
+        name="test",
+        label=[],
+        ref="ex:target1",
+        children=[Child(value=42, ref="ex:child_ref")],
+    )
+    j = ctrl.to_json()
+    restored = Parent.from_json(j)
+    assert restored.__iris__.get("ref") == "ex:target1"
+    ch = restored.__dict__["children"][0]
+    assert ch.__iris__.get("ref") == "ex:child_ref"
+    assert ch.value == 42
+
+
+def test_controller_from_model_preserves_iris():
+    """ParentController(parent_model) preserves nested IRIs."""
+    parent = Parent(
+        name="src",
+        label=[],
+        ref="ex:parent_ref",
+        children=[Child(value=7, ref="ex:nested_ref")],
+    )
+    ctrl = ParentController(parent, ctrl_field="custom")
+    assert ctrl.__iris__.get("ref") == "ex:parent_ref"
+    ch = ctrl.__dict__["children"][0]
+    assert ch.__iris__.get("ref") == "ex:nested_ref"
+    assert ctrl.ctrl_field == "custom"

--- a/tests/test_oold.py
+++ b/tests/test_oold.py
@@ -328,6 +328,104 @@ def test_cast_v2():
     _run_cast_tests("v2")
 
 
+def _run_nested_iris_cast_tests(pydantic_version="v2"):
+    """Test that __iris__ on nested objects survives cast() and constructor."""
+    from typing import Optional
+
+    if pydantic_version == "v1":
+        from pydantic.v1 import Field as PydField
+
+        from oold.model.v1 import LinkedBaseModel
+    else:
+        from oold.model import LinkedBaseModel
+        from pydantic import Field as PydField
+
+    from pydantic import ConfigDict
+
+    if pydantic_version == "v1":
+
+        class Child(LinkedBaseModel):
+            class Config:
+                schema_extra = {
+                    "@context": [{"ref": {"@id": "Property:HasRef", "@type": "@id"}}],
+                    "title": "Child",
+                }
+
+            value: int = 0
+            ref: Optional[str] = PydField(None, range="Category:Target")
+
+        class Parent(LinkedBaseModel):
+            name: str = "parent"
+            children: Optional[List[Child]] = None
+
+        class ParentController(LinkedBaseModel):
+            name: str = "parent"
+            children: Optional[List[Child]] = None
+            extra: str = "ctrl"
+
+    else:
+
+        class Child(LinkedBaseModel):
+            model_config = ConfigDict(
+                json_schema_extra={
+                    "@context": [{"ref": {"@id": "Property:HasRef", "@type": "@id"}}],
+                    "title": "Child",
+                },
+            )
+            value: int = 0
+            ref: Optional[str] = PydField(
+                None, json_schema_extra={"range": "Category:Target"}
+            )
+
+        class Parent(LinkedBaseModel):
+            name: str = "parent"
+            children: Optional[List[Child]] = None
+
+        class ParentController(LinkedBaseModel):
+            name: str = "parent"
+            children: Optional[List[Child]] = None
+            extra: str = "ctrl"
+
+    # Create parent with children that have IRI refs
+    p = Parent(
+        name="p1",
+        children=[
+            Child(value=1, ref="ex:target1"),
+            Child(value=2, ref="ex:target2"),
+        ],
+    )
+
+    # Verify __iris__ on children
+    assert p.__dict__["children"][0].__iris__.get("ref") == "ex:target1"
+    assert p.__dict__["children"][1].__iris__.get("ref") == "ex:target2"
+
+    # dict() should include IRI refs for nested objects
+    d = p.dict()
+    assert d["children"][0]["ref"] == "ex:target1"
+    assert d["children"][1]["ref"] == "ex:target2"
+    assert d["children"][0]["value"] == 1
+
+    # cast() should preserve __iris__ on nested objects
+    pc = p.cast(ParentController, extra="casted")
+    assert pc.extra == "casted"
+    assert pc.__dict__["children"][0].__iris__.get("ref") == "ex:target1"
+    assert pc.__dict__["children"][1].__iris__.get("ref") == "ex:target2"
+
+    # Constructor Model(model_instance) should also preserve
+    pc2 = ParentController(p, extra="ctor")
+    assert pc2.extra == "ctor"
+    assert pc2.__dict__["children"][0].__iris__.get("ref") == "ex:target1"
+    assert pc2.__dict__["children"][1].__iris__.get("ref") == "ex:target2"
+
+
+def test_nested_iris_cast_v1():
+    _run_nested_iris_cast_tests("v1")
+
+
+def test_nested_iris_cast_v2():
+    _run_nested_iris_cast_tests("v2")
+
+
 if __name__ == "__main__":
     _run("v1")
     _run("v2")


### PR DESCRIPTION
- Add dict() override to v1 LinkedBaseModel (mirrors v2 model_dump): includes _object_to_iri + _recursive_object_to_iri for IRI injection
- cast() (v1+v2): use raw Pydantic dict/model_dump + _recursive_object_to_iri to preserve inline objects (previous dict() replaced them with IRIs)
- __init__ model-instance path (v1): same raw dict approach
- to_json() (v1+v2): re-inject __iris__ values excluded by exclude_none
- Removes _inject_nested_iris workaround (no longer needed)