### PR TITLE
docs: zenodo authorship mechanism through CITATION.cff

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,3 +1,0 @@
-# Contributors
-
-* SimonStier [simon.stier@isc.fraunhofer.de](mailto:simon.stier@isc.fraunhofer.de)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,3 +7,15 @@ repository-code: "https://github.com/OO-LD/oold-python"
 url: "https://OO-LD.github.io/oold-python/"
 license: MIT
 doi: 10.5281/zenodo.8374237
+# Authors listed here are the creators shown on each Zenodo release.
+# Listing is opt-in: to be added, open a PR (see CONTRIBUTING.md, "Citation and authorship").
+authors:
+  - given-names: Simon
+    family-names: Stier
+    orcid: "https://orcid.org/0000-0003-0410-3616"
+  - given-names: Lukas
+    family-names: Gold
+    orcid: "https://orcid.org/0000-0001-7444-2969"
+  - given-names: Andreas
+    family-names: Räder
+    orcid: "https://orcid.org/0000-0002-2673-0832"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,6 +7,3 @@ repository-code: "https://github.com/OO-LD/oold-python"
 url: "https://OO-LD.github.io/oold-python/"
 license: MIT
 doi: 10.5281/zenodo.8374237
-authors:
-  - name: "OO-LD Contributors"
-    website: "https://github.com/OO-LD/oold-python/graphs/contributors"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,30 @@ Releases are published automatically by CI when a version tag is pushed.
 
 CI will build the package (`uv build`), publish it to PyPI, and deploy the docs to GitHub Pages. The version is derived from the git tag via `hatch-vcs`, so no manual version bumping is needed.
 
+## Citation and authorship
+
+Authors of the project are listed explicitly in [`CITATION.cff`](CITATION.cff). This list is the set of creators shown on each [Zenodo](https://zenodo.org/doi/10.5281/zenodo.8374237) release. We keep it opt-in and curated rather than auto-generated from GitHub, so nobody is listed without consent, and the entries in `CITATION.cff` take precedence over GitHub's automatic contributor detection.
+
+To be officially listed as an author for future Zenodo releases, add yourself to the `authors:` list in `CITATION.cff`. Two ways, in order of preference:
+
+1. **Preferred - within your feature PR:** include the `CITATION.cff` edit directly in the same PR that contributes your feature or fix, so authorship is recorded together with the work.
+2. **Standalone PR:** if you are already a GitHub contributor and simply want to be listed as an author on Zenodo, open a single PR that only adds your entry.
+
+In either case, add an entry like:
+
+```yaml
+  - given-names: Your
+    family-names: Name
+    affiliation: "Your institution"                 # optional
+    orcid: "https://orcid.org/0000-0000-0000-0000"  # optional, use your real ORCID
+```
+
+Notes:
+
+- Append yourself to the end of the list (order is the citation order); mention it in the PR if a different position is intended.
+- `affiliation` and `orcid` are optional but recommended for durable, unambiguous attribution.
+- Only entries present in `CITATION.cff` at the tagged commit appear on that release's Zenodo record, so add yourself before a release to be included.
+
 ## AI Guidelines
 
 We believe that AI, and in particular LLMs, can be helpful conventional tools to accelerate development and improve quality when used responsibly. AI or any other tool is never the author of code; a human developer always is. Therefore, it is mandatory to carefully review all generated content for correctness, quality, and the absence of legal and ethical issues. For consistency, please avoid patterns that are hard to maintain manually, such as duplicated content or special characters like em dashes or UTF icons.

--- a/README.md
+++ b/README.md
@@ -274,16 +274,3 @@ pre-commit install
 ```
 
 Please also enable GitHub Actions on your fork so the test suite runs automatically.
-
-## Citation
-
-If you use oold-python in your research, please cite it:
-
-```bibtex
-@software{oold_python,
-  author  = {OO-LD Contributors},
-  title   = {oold-python: Object Oriented Linked Data for Python},
-  url     = {https://github.com/OO-LD/oold-python},
-  doi     = {10.5281/zenodo.8374237},
-}
-```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -101,6 +101,32 @@ CI will build the package (`uv build`), publish it to PyPI, and deploy the docs 
 
 ---
 
+## Citation and authorship
+
+Authors of the project are listed explicitly in `CITATION.cff`. This list is the set of creators shown on each [Zenodo](https://zenodo.org/doi/10.5281/zenodo.8374237) release. We keep it opt-in and curated rather than auto-generated from GitHub, so nobody is listed without consent, and the entries in `CITATION.cff` take precedence over GitHub's automatic contributor detection.
+
+To be officially listed as an author for future Zenodo releases, add yourself to the `authors:` list in `CITATION.cff`. Two ways, in order of preference:
+
+1. **Preferred - within your feature PR:** include the `CITATION.cff` edit directly in the same PR that contributes your feature or fix, so authorship is recorded together with the work.
+2. **Standalone PR:** if you are already a GitHub contributor and simply want to be listed as an author on Zenodo, open a single PR that only adds your entry.
+
+In either case, add an entry like:
+
+```yaml
+  - given-names: Your
+    family-names: Name
+    affiliation: "Your institution"                 # optional
+    orcid: "https://orcid.org/0000-0000-0000-0000"  # optional, use your real ORCID
+```
+
+Notes:
+
+- Append yourself to the end of the list (order is the citation order); mention it in the PR if a different position is intended.
+- `affiliation` and `orcid` are optional but recommended for durable, unambiguous attribution.
+- Only entries present in `CITATION.cff` at the tagged commit appear on that release's Zenodo record, so add yourself before a release to be included.
+
+---
+
 ## AI Guidelines
 
 We believe that AI, and in particular LLMs, can be helpful conventional tools to accelerate development and improve quality when used responsibly. AI or any other tool is never the author of code; a human developer always is. Therefore, it is mandatory to carefully review all generated content for correctness, quality, and the absence of legal and ethical issues. For consistency, please avoid patterns that are hard to maintain manually, such as duplicated content or special characters like em dashes or UTF icons.


### PR DESCRIPTION
 to make use of auto contributor fetching from github (bots should be already ignored by default)
 
 Works with no cff file at all like on https://github.com/semos-org/semos-agentura , but only repo info.
 PR needed to be run pre-release test on existing cff file without any author info and trigger fetching from GitHub. 
 
 Nothing functional on source code changed.