### PR TITLE
chore(release): fix ci pipeline in general, and applies previous PR creates v0.16.3 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,6 +90,9 @@ jobs:
       - name: Compute release preview
         id: preview
         run: |
+          # PSR only computes a release on the main branch; name the checked-out
+          # PR head 'main' so the preview reflects what a merge would release.
+          git checkout -B main >/dev/null 2>&1 || true
           current=$(uv version --short 2>/dev/null || echo "unknown")
           next=$(uv run semantic-release version --print 2>/dev/null || echo "")
           if [ -n "$next" ] && [ "$next" != "$current" ]; then

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,9 +102,14 @@ jobs:
           fi
           echo "current=$current" >> "$GITHUB_OUTPUT"
           echo "next=$next" >> "$GITHUB_OUTPUT"
+          # Stamp the upcoming changelog section locally (no commit/tag/push/build)
+          # so the preview shows the notes this merge would add.
+          if [ -n "$next" ] && [ "$next" != "$current" ]; then
+            uv run semantic-release version --no-commit --no-tag --no-push --no-vcs-release --skip-build >/dev/null 2>&1 || true
+          fi
           {
             echo "changelog<<PSR_EOF"
-            uv run semantic-release changelog --print 2>/dev/null | head -60 || echo "(no changelog preview)"
+            git --no-pager diff HEAD -- CHANGELOG.md | awk '/^\+/ && !/^\+\+\+/ {sub(/^\+/,""); print}' | head -80
             echo "PSR_EOF"
           } >> "$GITHUB_OUTPUT"
 
@@ -115,7 +120,7 @@ jobs:
           message: |
             ## Release preview
 
-            ${{ steps.preview.outputs.released == 'true' && format('Merging this PR would release **v{0}** (current: `{1}`).', steps.preview.outputs.next, steps.preview.outputs.current) || format('No version bump from the current commits (stays at `{0}`). Use conventional commit types (`feat`, `fix`, ...) to trigger a release.', steps.preview.outputs.current) }}
+            ${{ steps.preview.outputs.released == 'true' && format('Merging this PR would release **v{0}** (current: `v{1}`).', steps.preview.outputs.next, steps.preview.outputs.current) || format('No version bump from the current commits (stays at `v{0}`). Use conventional commit types (`feat`, `fix`, ...) to trigger a release.', steps.preview.outputs.current) }}
 
             <details><summary>Changelog preview (truncated)</summary>
 
@@ -125,7 +130,7 @@ jobs:
 
             </details>
 
-            <sub>Computed by python-semantic-release from the conventional commits on this branch.</sub>
+            <sub>Preview via python-semantic-release and conventional commits.</sub>
 
   benchmark:
     runs-on: ubuntu-latest

--- a/.github/workflows/on-release-main.yml
+++ b/.github/workflows/on-release-main.yml
@@ -20,11 +20,19 @@ jobs:
       released: ${{ steps.version.outputs.released }}
       version: ${{ steps.version.outputs.version }}
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Check out
         uses: actions/checkout@v4
         with:
           fetch-depth: 0   # full history + tags so PSR can analyze commits
           ref: main
+          token: ${{ steps.app-token.outputs.token }}   # app identity bypasses the main ruleset
 
       - name: Set up the environment
         uses: ./.github/actions/setup-python-env
@@ -37,7 +45,7 @@ jobs:
       - name: Semantic release version
         id: version
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           before=$(git rev-parse HEAD)
           uv run semantic-release version


### PR DESCRIPTION
## Summary

- Fixes the release job failing with GH013 (default GITHUB_TOKEN cannot push to PR-protected main).
- Adds actions/create-github-app-token step ([RELEASE_APP_ID / RELEASE_APP_PRIVATE_KEY](https://github.com/organizations/OO-LD/settings/secrets/actions)).
- Uses that app token for actions/checkout (the push) and as GH_TOKEN for semantic-release.
- App [oold-release-bot](https://github.com/organizations/OO-LD/settings/installations) is on the ruleset bypass, so PSR can push the release commit + tag.
- Token is short-lived, scoped to Contents: write, minted per run.
- No change when there is no version bump (release stays skipped).
- [Ruleset](https://github.com/OO-LD/oold-python/settings/rules) cleanup: removed the Write-role bypass, only the app bypasses now.
